### PR TITLE
fix(clipcc): 修复返回对象缺少分号的问题

### DIFF
--- a/src/engine/adapters/communities/clipcc/index.ts
+++ b/src/engine/adapters/communities/clipcc/index.ts
@@ -26,7 +26,7 @@ export default defineAdapter({
             works: response.pager.quantity,
             looks,
             likes
-        }
+        };
     },
     fields: {
         username: "clipcc"


### PR DESCRIPTION
fix(clipcc): 修复返回对象缺少分号的问题