### PR TITLE
feat: add GitHub logo and repo text to card

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "jiti": "^2.6.1",
         "tencentcloud-sdk-nodejs-teo": "^4.1.184",
         "tsup": "^8.5.1",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.54.0"
     },
     "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       typescript-eslint:
         specifier: ^8.54.0
         version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)

--- a/src/engine/dataHandler.ts
+++ b/src/engine/dataHandler.ts
@@ -21,12 +21,12 @@ export interface CardSetting {
     theme: ThemeType;
     color: string;
 }
-export interface ParamInput extends Partial<{
+export type ParamInput = Partial<{
     rankSystem: RankSystem;
     username: string;
     color: string;
     theme: ThemeType
-}> { }
+}>;
 export interface UserProfileHandler {
     (user: string, request: Request): Promise<UserProfile>;
 }
@@ -42,11 +42,11 @@ export interface CommunityAdapter<U extends string = string, R extends string | 
     };
 }
 
-export const adapterStore: Record<string, CommunityAdapter> = {};
-export function defineAdapter<U extends string, R extends string>(data: CommunityAdapter<U, R>) {
+export const adapterStore: Record<string, CommunityAdapter<string, string | undefined>> = {};
+export function defineAdapter<U extends string, R extends string | undefined = undefined>(data: CommunityAdapter<U, R>) {
     return data;
 }
-export function registerAdapter(...adapters: CommunityAdapter[]) {
+export function registerAdapter(...adapters: CommunityAdapter<string, string | undefined>[]) {
     for (const adapter of adapters) {
         adapterStore[adapter.communityName] = adapter;
         if (adapter.fields.rank && adapter.fields.rank.system) {

--- a/src/engine/generator.ts
+++ b/src/engine/generator.ts
@@ -4,7 +4,7 @@ import { calculateProgress, normalize, RankLevelLabels, RankLevelStore, rankStor
 import { ThemeType } from "./themeConfig";
 
 export interface AdaptiveResult {
-    adapter: CommunityAdapter;
+    adapter: CommunityAdapter<string, string | undefined>;
     username: string;
 }
 export interface GenerateStatus {

--- a/src/templates/card.svg
+++ b/src/templates/card.svg
@@ -1,4 +1,4 @@
-<svg width="400" height="150" viewBox="0 0 400 150" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="400" height="175" viewBox="0 0 400 175" fill="none" xmlns="http://www.w3.org/2000/svg">
     <style>
         .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;
@@ -80,7 +80,7 @@
             animation-delay: 0.4s;
         }
     </style>
-    <rect x="0.5" y="0.5" rx="10" width="399" height="149" fill="__backgroundColor__" stroke="__borderColor__" />
+    <rect x="0.5" y="0.5" rx="10" width="399" height="174" fill="__backgroundColor__" stroke="__borderColor__" />
     <text x="25" y="35" class="header">__username__@__rankSystem__ [__rankScore__]</text>
     <g transform="translate(25, 70)">
         <g class="stat delay-1">
@@ -101,5 +101,9 @@
         <circle r="40" cx="0" cy="0" stroke="__themeColor__" stroke-width="8" fill="none" stroke-linecap="round"
             class="progress-bar" transform="rotate(-90)" />
         <text x="0" y="8" text-anchor="middle" class="rank-text">__rankResult__</text>
+    </g>
+    <g transform="translate(25, 145)" class="stat delay-2">
+        <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+        <text x="22" y="12" style="font: 400 12px 'Segoe UI', Ubuntu, Sans-Serif;">YearnstudioYangyi/scratch-readme-stats</text>
     </g>
 </svg>


### PR DESCRIPTION
Adds the repository URL and a small GitHub logo to the bottom left of the generated card. The color dynamically adapts to the current theme to ensure visibility on both light and dark backgrounds. Also includes minor TypeScript typing fixes in the engine.

---
*PR created automatically by Jules for task [15541234721783193577](https://jules.google.com/task/15541234721783193577) started by @YearnstudioYangyi*